### PR TITLE
fix: 不正なテンプレートパスを修正

### DIFF
--- a/generators/g-scaffold/index.js
+++ b/generators/g-scaffold/index.js
@@ -123,8 +123,8 @@ module.exports = class extends FileCopyGenerator {
       'customize.scss',
     ].forEach(fileName =>
       this.fs.copyTpl(
-        this.templatePath(`scaffold${fileName}.js`),
-        this.destinationPath(`apps/${appName}/${fileName}.js`),
+        this.templatePath(fileName),
+        this.destinationPath(`apps/${appName}/${fileName}`),
         { appName }
       )
     )


### PR DESCRIPTION
- scaffold でテストしたところ、テンプレートの取得元／配置先パスが不正なためエラーが発生
- パスを修正したところ正常に動作
